### PR TITLE
QUICK-FIX: add parse json request body middleware

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,5 +31,7 @@ module.exports = {
     'prettier/prettier': 'warn',
     //  we allow 0 warnings, so don't think prettier rules are ignored
     // this is only to show prettier issues as warnings, not errors
+    'jest/valid-describe': 'off',
+    //  too buggy rule: https://github.com/jest-community/eslint-plugin-jest/issues/203
   },
 }

--- a/packages/backend/middlewares.js
+++ b/packages/backend/middlewares.js
@@ -18,6 +18,18 @@ const errorMiddleware = recoveryMiddleware((error) => {
   }
 })
 
+const parseJSONRequestBodyMiddleware = (next) => async (event, context) => {
+  try {
+    const parsedBody = JSON.parse(event.body)
+    // JSON.parse('null') === null, JSON.parse('true') === true
+    if (type(parsedBody) === 'Object') {
+      // eslint-disable-next-line no-param-reassign
+      event.body = parsedBody
+    }
+  } catch (e) {} // eslint-disable-line no-empty
+  return next(event, context)
+}
+
 const stringifyJSONResponseMiddleware = (next) => async (event, context) => {
   const response = await next(event, context)
   const { body } = response
@@ -66,7 +78,8 @@ const createLambda = compose(
   stringifyJSONResponseMiddleware,
   errorMiddleware,
   convertResponseBodyMiddleware,
-  throwOnFalsyResponseMiddleware
+  throwOnFalsyResponseMiddleware,
+  parseJSONRequestBodyMiddleware
 )
 
 module.exports = {
@@ -77,4 +90,5 @@ module.exports = {
   addDefaultStatusCodeMiddleware,
   convertResponseBodyMiddleware,
   throwOnFalsyResponseMiddleware,
+  parseJSONRequestBodyMiddleware,
 }

--- a/packages/backend/middlewares.js
+++ b/packages/backend/middlewares.js
@@ -18,7 +18,7 @@ const errorMiddleware = recoveryMiddleware((error) => {
   }
 })
 
-const stringifyJSONMiddleware = (next) => async (event, context) => {
+const stringifyJSONResponseMiddleware = (next) => async (event, context) => {
   const response = await next(event, context)
   const { body } = response
   const bodyType = type(body)
@@ -63,7 +63,7 @@ const throwOnFalsyResponseMiddleware = (next) => async (event, context) => {
 const createLambda = compose(
   waitForEmptyEventLoopMiddleware,
   addDefaultStatusCodeMiddleware,
-  stringifyJSONMiddleware,
+  stringifyJSONResponseMiddleware,
   errorMiddleware,
   convertBodyMiddleware,
   throwOnFalsyResponseMiddleware
@@ -73,7 +73,7 @@ module.exports = {
   createLambda,
   waitForEmptyEventLoopMiddleware,
   errorMiddleware,
-  stringifyJSONMiddleware,
+  stringifyJSONResponseMiddleware,
   addDefaultStatusCodeMiddleware,
   convertBodyMiddleware,
   throwOnFalsyResponseMiddleware,

--- a/packages/backend/middlewares.js
+++ b/packages/backend/middlewares.js
@@ -30,7 +30,7 @@ const stringifyJSONResponseMiddleware = (next) => async (event, context) => {
   return response
 }
 
-const convertBodyMiddleware = (next) => async (event, context) => {
+const convertResponseBodyMiddleware = (next) => async (event, context) => {
   const response = await next(event, context)
   if (response.body === undefined) {
     return {
@@ -65,7 +65,7 @@ const createLambda = compose(
   addDefaultStatusCodeMiddleware,
   stringifyJSONResponseMiddleware,
   errorMiddleware,
-  convertBodyMiddleware,
+  convertResponseBodyMiddleware,
   throwOnFalsyResponseMiddleware
 )
 
@@ -75,6 +75,6 @@ module.exports = {
   errorMiddleware,
   stringifyJSONResponseMiddleware,
   addDefaultStatusCodeMiddleware,
-  convertBodyMiddleware,
+  convertResponseBodyMiddleware,
   throwOnFalsyResponseMiddleware,
 }

--- a/packages/backend/middlewares.test.js
+++ b/packages/backend/middlewares.test.js
@@ -1,6 +1,6 @@
 const {
   errorMiddleware,
-  stringifyJSONMiddleware,
+  stringifyJSONResponseMiddleware,
   convertBodyMiddleware,
   addDefaultStatusCodeMiddleware,
   throwOnFalsyResponseMiddleware,
@@ -49,12 +49,12 @@ describe('errorMiddleware', () => {
   })
 })
 
-describe('stringifyJSONMiddleware', () => {
+describe('stringifyJSONResponseMiddleware', () => {
   it('stringifies response.body if it is object', async () => {
     const handler = async () => ({
       body: { ok: true, items: [1, 2, 3, 4] },
     })
-    const wrappedHandler = stringifyJSONMiddleware(handler)
+    const wrappedHandler = stringifyJSONResponseMiddleware(handler)
 
     const response = await wrappedHandler()
 
@@ -66,7 +66,7 @@ describe('stringifyJSONMiddleware', () => {
     const handler = async () => ({
       body: [1, 2, 3],
     })
-    const wrappedHandler = stringifyJSONMiddleware(handler)
+    const wrappedHandler = stringifyJSONResponseMiddleware(handler)
 
     try {
       await wrappedHandler()

--- a/packages/backend/middlewares.test.js
+++ b/packages/backend/middlewares.test.js
@@ -1,7 +1,7 @@
 const {
   errorMiddleware,
   stringifyJSONResponseMiddleware,
-  convertBodyMiddleware,
+  convertResponseBodyMiddleware,
   addDefaultStatusCodeMiddleware,
   throwOnFalsyResponseMiddleware,
   createLambda,
@@ -77,10 +77,10 @@ describe('stringifyJSONResponseMiddleware', () => {
   })
 })
 
-describe('convertBodyMiddleware', () => {
+describe('convertResponseBodyMiddleware', () => {
   it('converts body, allows just return body in lambda function', async () => {
     const handler = async () => ({ ok: true })
-    const wrappedHandler = convertBodyMiddleware(handler)
+    const wrappedHandler = convertResponseBodyMiddleware(handler)
 
     expect(await wrappedHandler()).toEqual({ body: { ok: true } })
   })

--- a/packages/backend/middlewares.test.js
+++ b/packages/backend/middlewares.test.js
@@ -18,7 +18,13 @@ const INTERNAL_SERVER_ERROR_RESPONSE = {
 const KIND_RETURNED_UNDEFINED_ERROR =
   'please check that you return something in your function'
 
+const originalConsoleError = console.error
+
 describe('errorMiddleware', () => {
+  afterEach(() => {
+    console.error = originalConsoleError
+  })
+
   it('returns 500 if handler throws error', async () => {
     const handler = async () => {
       throw new Error('test')
@@ -156,6 +162,7 @@ describe('createLambda', () => {
 
     expect(response).toEqual(INTERNAL_SERVER_ERROR_RESPONSE)
     expect(console.error).toHaveBeenCalled()
+    console.error = originalConsoleError
   })
 
   it('allows to set statusCode in handler', async () => {
@@ -181,6 +188,7 @@ describe('createLambda', () => {
     expect(console.error).toHaveBeenCalled()
     const loggedErrorMessage = console.error.mock.calls[0][0].message
     expect(loggedErrorMessage).toContain(KIND_RETURNED_UNDEFINED_ERROR)
+    console.error = originalConsoleError
   })
 
   it('allows to set headers', async () => {


### PR DESCRIPTION
# Problem statement

Need to manually parse json in request.body in each handler

# Solution description

Create middleware, write tests for it.

Disable eslint `jest/valid-describe` as it is flawed: https://github.com/jest-community/eslint-plugin-jest/issues/203
