### PR TITLE
Escape plus in includes query method

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "dotenv": "^8.2.0",
+    "escape-string-regexp": "^2.0.0",
     "matcher": "^2.0.0",
     "mongodb": "^3.3.3",
     "serverless-compose": "^2.4.0",

--- a/packages/backend/src/orders-logic.test.js
+++ b/packages/backend/src/orders-logic.test.js
@@ -184,5 +184,40 @@ describe('orders-logic', () => {
         })
       )
     })
+
+    const propertiesToTest = ['mainPhone', 'additionalPhone']
+
+    propertiesToTest.forEach((propertyName) => {
+      it(`finds orders by ${propertyName}`, async () => {
+        await insertOrders([
+          {
+            [propertyName]: '+123',
+          },
+          {
+            [propertyName]: '+12345',
+          },
+          {
+            [propertyName]: '+987',
+          },
+          {
+            [propertyName]: undefined,
+          },
+        ])
+
+        const foundItems = await findOrders({ phone: '+123' })
+
+        expect(foundItems).toHaveLength(2)
+        expect(foundItems[0]).toEqual(
+          expect.objectContaining({
+            [propertyName]: '+123',
+          })
+        )
+        expect(foundItems[1]).toEqual(
+          expect.objectContaining({
+            [propertyName]: '+12345',
+          })
+        )
+      })
+    })
   })
 })

--- a/packages/backend/src/query-utils.js
+++ b/packages/backend/src/query-utils.js
@@ -1,7 +1,9 @@
+const escapeStringRegexp = require('escape-string-regexp')
+
 class QueryUtils {
   static includes(property, value) {
     if (!value) return {}
-    const regexFilter = new RegExp(value, 'i')
+    const regexFilter = new RegExp(escapeStringRegexp(value), 'i')
     return {
       [property]: regexFilter,
     }


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/1m70VKvc/87-internal-server-error-on-phone-search-with-sign)

# Problem statement

Internal server error on phone search with "+" sign

# Solution description

Escape regex in `includes` mongo filter on backend